### PR TITLE
Object? instead of dynamic for AuthStore

### DIFF
--- a/lib/src/async_auth_store.dart
+++ b/lib/src/async_auth_store.dart
@@ -55,7 +55,7 @@ class AsyncAuthStore extends AuthStore {
   @override
   void save(
     String newToken,
-    dynamic /* RecordModel|AdminModel|null */ newModel,
+    Object? /* RecordModel|AdminModel|null */ newModel,
   ) {
     super.save(newToken, newModel);
 
@@ -94,7 +94,7 @@ class AsyncAuthStore extends AuthStore {
 
     final rawModel = decoded[_modelKey] as Map<String, dynamic>? ?? {};
 
-    dynamic model;
+    Object? model;
     if (rawModel.containsKey("collectionId") ||
         rawModel.containsKey("collectionName") ||
         rawModel.containsKey("verified") ||

--- a/lib/src/auth_store.dart
+++ b/lib/src/auth_store.dart
@@ -6,7 +6,7 @@ class AuthStoreEvent {
   AuthStoreEvent(this.token, this.model);
 
   final String token;
-  final dynamic /* RecordModel|AdminModel|null */ model;
+  final Object? /* RecordModel|AdminModel|null */ model;
 
   @override
   String toString() => "token: $token\nmodel: $model";
@@ -16,14 +16,14 @@ class AuthStoreEvent {
 /// the authenticated User/Admin model and its token.
 class AuthStore {
   String _token = "";
-  dynamic /* RecordModel|AdminModel|null */ _model;
+  Object? /* RecordModel|AdminModel|null */ _model;
   final _onChangeController = StreamController<AuthStoreEvent>.broadcast();
 
   /// Returns the saved auth token (if any).
   String get token => _token;
 
   /// Returns the saved auth model (if any).
-  dynamic /* RecordModel|AdminModel|null */ get model => _model;
+  Object? /* RecordModel|AdminModel|null */ get model => _model;
 
   /// Stream that gets triggered on each auth store change
   /// (aka. on [save()] and [clear()] call).
@@ -51,7 +51,7 @@ class AuthStore {
   /// Saves the provided [newToken] and [newModel] auth data into the store.
   void save(
     String newToken,
-    dynamic /* RecordModel|AdminModel|null */ newModel,
+    Object? /* RecordModel|AdminModel|null */ newModel,
   ) {
     _token = newToken;
     _model = newModel;


### PR DESCRIPTION
When working with Dart using Object? instead of dynamic leads to a better API since the Model can be null.