### PR TITLE
Refactor: Include `id` in the model's dynamic data

### DIFF
--- a/lib/src/dtos/record_model.dart
+++ b/lib/src/dtos/record_model.dart
@@ -61,7 +61,6 @@ class RecordModel implements Jsonable {
     // attach the dynamic json fields to the model"s `data`
     // ---
     final baseFields = <String>[
-      "id",
       "created",
       "updated",
       "collectionId",


### PR DESCRIPTION
Refactor: Include `id` in the model's dynamic data

- Modified the list of base fields to exclude `id`.
- Ensured `id` is retained in the dynamic data attached to the model.
- Updated base fields list to only exclude "created", "updated", "collectionId", "collectionName", and "expand".


this will solve my personal problem:

```dart
class PBCategoriHttpRepo implements CategoriService {
  @override
  Future<List<CategoriModel>> getCategori() async {
    final pb = PocketBase('https://pb.palen.id');
    try {
      final records = await pb.collection('categories').getFullList();
      return records.map((record) {
        // current approach,  i need to spread data and add id manually. 
        return CategoriModel.fromMap({"id": record.id, ...record.data});
      }).toList();
    } catch (e) {
      rethrow;
    }
  }
}
```