### PR TITLE
Fix: send ClientException if target server replies with 301 or 308

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -232,7 +232,7 @@ class PocketBase {
         responseData = responseStr;
       }
 
-      if (response.statusCode >= 400) {
+      if (response.statusCode >= 400 || [301, 308].contains(response.statusCode)) {
         throw ClientException(
           url: url,
           statusCode: response.statusCode,


### PR DESCRIPTION
Handles #59. 

The fix might not be up to the HTTP standard, but the caller should be able to act upon receiving [301 Moved Permanently](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/301) or [308 Permanent Redirect](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308)