### PR TITLE
fix: use UTC DateTime in filter test to avoid timezone issues

### DIFF
--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -81,7 +81,7 @@ void main() {
         "test5": 123,
         "test6": -123.45,
         "test7": 123.45,
-        "test8": DateTime(2023, 10, 18, 10, 11, 12),
+        "test8": DateTime.utc(2023, 10, 18, 10, 11, 12),
         "test9": [1, 2, 3, "test'123"],
         "test10": {"a": "test'123"},
       };
@@ -97,7 +97,7 @@ void main() {
 
       expect(
         client.filter(expr, params),
-        "test1='a\\'b\\'c\\'' || test2=null || test3=true || test4=false || test5=123 || test6=-123.45 || test7=123.45 || test8='2023-10-18 07:11:12.000Z' || test9='[1,2,3,\"test\\'123\"]' || test10='{\"a\":\"test\\'123\"}'",
+        "test1='a\\'b\\'c\\'' || test2=null || test3=true || test4=false || test5=123 || test6=-123.45 || test7=123.45 || test8='2023-10-18 10:11:12.000Z' || test9='[1,2,3,\"test\\'123\"]' || test10='{\"a\":\"test\\'123\"}'",
       );
     });
   });


### PR DESCRIPTION
Changed DateTime(2023, 10, 18, 10, 11, 12) to DateTime.utc() to make the test timezone-independent and prevent failures on different systems.