### PR TITLE
feat: implement request cancellation/abort feature

### DIFF
--- a/example/cancellation_example.dart
+++ b/example/cancellation_example.dart
@@ -1,0 +1,193 @@
+// Example demonstrating request cancellation/abort feature in PocketBase Dart SDK
+
+import "package:pocketbase/pocketbase.dart";
+
+void main() async {
+  final pb = PocketBase("http://127.0.0.1:8090");
+
+  // Example 1: Manual cancellation with CancelToken
+  print("Example 1: Manual cancellation");
+  final cancelToken = CancelToken();
+  
+  // Start a request
+  final future = pb.collection("posts").getList(cancelToken: cancelToken);
+  
+  // Cancel it after 100ms
+  Future.delayed(const Duration(milliseconds: 100), () {
+    cancelToken.cancel("User cancelled the request");
+  });
+  
+  try {
+    await future;
+    print("Request completed");
+  } catch (e) {
+    if (e is ClientException && e.isAbort) {
+      print("Request was cancelled: ${e.originalError}");
+    }
+  }
+
+  // Example 2: Auto-cancellation of duplicate requests
+  print("\nExample 2: Auto-cancellation");
+  
+  // These requests will auto-cancel each other
+  final request1 = pb.collection("posts").getList(); // Will be cancelled
+  final request2 = pb.collection("posts").getList(); // Will be cancelled  
+  final request3 = pb.collection("posts").getList(); // Will execute
+  
+  try {
+    await request1;
+  } catch (e) {
+    if (e is ClientException && e.isAbort) {
+      print("Request 1 was auto-cancelled");
+    }
+  }
+  
+  try {
+    await request2;
+  } catch (e) {
+    if (e is ClientException && e.isAbort) {
+      print("Request 2 was auto-cancelled");
+    }
+  }
+  
+  try {
+    final result = await request3;
+    print("Request 3 completed with ${result.items.length} items");
+  } catch (e) {
+    print("Request 3 failed: $e");
+  }
+
+  // Example 3: Disable auto-cancellation
+  print("\nExample 3: Disable auto-cancellation");
+  
+  // Disable auto-cancellation globally
+  pb.autoCancellation(false);
+  
+  // These requests will all execute
+  final req1 = pb.collection("posts").getList();
+  final req2 = pb.collection("posts").getList();
+  
+  try {
+    final results = await Future.wait([req1, req2]);
+    print("Both requests completed: ${results.length} results");
+  } catch (e) {
+    print("Requests failed: $e");
+  }
+
+  // Example 4: Disable auto-cancellation per request
+  print("\nExample 4: Disable auto-cancellation per request");
+  
+  // Re-enable auto-cancellation globally
+  pb.autoCancellation(true);
+  
+  // Use requestKey: null to disable auto-cancellation for specific requests
+  final reqA = pb.collection("posts").getList(requestKey: null);
+  final reqB = pb.collection("posts").getList(requestKey: null);
+  
+  try {
+    final results = await Future.wait([reqA, reqB]);
+    print("Both requests completed without cancellation: "
+        "${results.length} results");
+  } catch (e) {
+    print("Requests failed: $e");
+  }
+
+  // Example 5: Custom request keys
+  print("\nExample 5: Custom request keys");
+  
+  // Use custom keys for different types of operations
+  final searchReq1 = pb.collection("posts").getList(requestKey: "search");
+  final searchReq2 = pb.collection("posts").getList(
+      requestKey: "search"); // Will cancel searchReq1
+  final loadReq = pb.collection("users").getList(
+      requestKey: "load"); // Different key, won't be cancelled
+  
+  try {
+    await searchReq1;
+  } catch (e) {
+    if (e is ClientException && e.isAbort) {
+      print("Search request 1 was cancelled");
+    }
+  }
+  
+  try {
+    final results = await Future.wait([searchReq2, loadReq]);
+    print("Search 2 and load completed: ${results.length} results");
+  } catch (e) {
+    print("Requests failed: $e");
+  }
+
+  // Example 6: Manual request cancellation
+  print("\nExample 6: Manual request cancellation");
+  
+  // Start multiple requests with custom keys
+  final task1 = pb.collection("posts").getList(requestKey: "task1");
+  final task2 = pb.collection("users").getList(requestKey: "task2");
+  
+  // Cancel specific request
+  pb.cancelRequest("task1");
+  
+  try {
+    await task1;
+  } catch (e) {
+    if (e is ClientException && e.isAbort) {
+      print("Task 1 was manually cancelled");
+    }
+  }
+  
+  try {
+    final result = await task2;
+    print("Task 2 completed with ${result.items.length} items");
+  } catch (e) {
+    print("Task 2 failed: $e");
+  }
+
+  // Example 7: Cancel all requests
+  print("\nExample 7: Cancel all requests");
+  
+  // Start multiple requests
+  final batchReq1 = pb.collection("posts").getList(requestKey: "batch1");
+  final batchReq2 = pb.collection("users").getList(requestKey: "batch2");
+  final batchReq3 = pb.collection("categories").getList(requestKey: "batch3");
+  
+  // Cancel all pending requests
+  pb.cancelAllRequests();
+  
+  // Check which requests were cancelled
+  final results = <String>[];
+  
+  try {
+    await batchReq1;
+    results.add("batch1: completed");
+  } catch (e) {
+    if (e is ClientException && e.isAbort) {
+      results.add("batch1: cancelled");
+    } else {
+      results.add("batch1: failed");
+    }
+  }
+  
+  try {
+    await batchReq2;
+    results.add("batch2: completed");
+  } catch (e) {
+    if (e is ClientException && e.isAbort) {
+      results.add("batch2: cancelled");
+    } else {
+      results.add("batch2: failed");
+    }
+  }
+  
+  try {
+    await batchReq3;
+    results.add("batch3: completed");
+  } catch (e) {
+    if (e is ClientException && e.isAbort) {
+      results.add("batch3: cancelled");
+    } else {
+      results.add("batch3: failed");
+    }
+  }
+  
+  print("Batch results: $results");
+}

--- a/lib/pocketbase.dart
+++ b/lib/pocketbase.dart
@@ -5,6 +5,7 @@ library;
 // main
 export "src/async_auth_store.dart";
 export "src/auth_store.dart";
+export "src/cancel_token.dart";
 export "src/client.dart";
 export "src/client_exception.dart";
 

--- a/lib/src/cancel_token.dart
+++ b/lib/src/cancel_token.dart
@@ -1,0 +1,80 @@
+import "dart:async";
+
+/// A token that can be used to signal cancellation to HTTP requests.
+/// 
+/// Similar to JavaScript's AbortController, this allows cancelling
+/// ongoing HTTP requests.
+class CancelToken {
+  final Completer<void> _completer = Completer<void>();
+  bool _isCancelled = false;
+  String? _reason;
+
+  /// Creates a new [CancelToken].
+  CancelToken();
+
+  /// Whether this token has been cancelled.
+  bool get isCancelled => _isCancelled;
+
+  /// The reason for cancellation, if any.
+  String? get reason => _reason;
+
+  /// A future that completes when this token is cancelled.
+  Future<void> get whenCancelled => _completer.future;
+
+  /// Cancels this token with an optional reason.
+  /// 
+  /// Once cancelled, this token cannot be reused.
+  void cancel([String? reason]) {
+    if (_isCancelled) {
+      return;
+    }
+
+    _isCancelled = true;
+    _reason = reason ?? "Request was cancelled";
+
+    if (!_completer.isCompleted) {
+      _completer.complete();
+    }
+  }
+
+  /// Throws a [CancellationException] if this token is cancelled.
+  void throwIfCancelled() {
+    if (_isCancelled) {
+      throw CancellationException(_reason ?? "Request was cancelled");
+    }
+  }
+
+  /// Returns a new [CancelToken] that will be cancelled when either
+  /// this token or the [other] token is cancelled.
+  CancelToken combine(CancelToken other) {
+    final combined = CancelToken();
+
+    void cancelCombined(String? reason) {
+      if (!combined.isCancelled) {
+        combined.cancel(reason);
+      }
+    }
+
+    if (isCancelled) {
+      cancelCombined(_reason);
+    } else if (other.isCancelled) {
+      cancelCombined(other._reason);
+    } else {
+      whenCancelled.then((_) => cancelCombined(_reason));
+      other.whenCancelled.then((_) => cancelCombined(other._reason));
+    }
+
+    return combined;
+  }
+}
+
+/// Exception thrown when a request is cancelled.
+class CancellationException implements Exception {
+  /// The reason for cancellation.
+  final String message;
+
+  const CancellationException(this.message);
+
+  @override
+  String toString() => "CancellationException: $message";
+}

--- a/lib/src/services/base_crud_service.dart
+++ b/lib/src/services/base_crud_service.dart
@@ -1,5 +1,6 @@
 import "package:http/http.dart" as http;
 
+import "../cancel_token.dart";
 import "../client_exception.dart";
 import "../dtos/jsonable.dart";
 import "../dtos/result_list.dart";
@@ -26,6 +27,8 @@ abstract class BaseCrudService<M extends Jsonable> extends BaseService {
     String? fields,
     Map<String, dynamic> query = const {},
     Map<String, String> headers = const {},
+    CancelToken? cancelToken,
+    Object? requestKey = const Object(),
   }) {
     final result = <M>[];
 
@@ -40,6 +43,8 @@ abstract class BaseCrudService<M extends Jsonable> extends BaseService {
         expand: expand,
         query: query,
         headers: headers,
+        cancelToken: cancelToken,
+        requestKey: requestKey,
       ).then((list) {
         result.addAll(list.items);
 
@@ -65,6 +70,8 @@ abstract class BaseCrudService<M extends Jsonable> extends BaseService {
     String? fields,
     Map<String, dynamic> query = const {},
     Map<String, String> headers = const {},
+    CancelToken? cancelToken,
+    Object? requestKey = const Object(),
   }) {
     final enrichedQuery = Map<String, dynamic>.of(query);
     enrichedQuery["page"] = page;
@@ -80,6 +87,8 @@ abstract class BaseCrudService<M extends Jsonable> extends BaseService {
           baseCrudPath,
           query: enrichedQuery,
           headers: headers,
+          cancelToken: cancelToken,
+          requestKey: requestKey,
         )
         .then((data) => ResultList<M>.fromJson(data, itemFactoryFunc));
   }
@@ -93,6 +102,8 @@ abstract class BaseCrudService<M extends Jsonable> extends BaseService {
     String? fields,
     Map<String, dynamic> query = const {},
     Map<String, String> headers = const {},
+    CancelToken? cancelToken,
+    Object? requestKey = const Object(),
   }) async {
     if (id.isEmpty) {
       throw ClientException(
@@ -115,6 +126,8 @@ abstract class BaseCrudService<M extends Jsonable> extends BaseService {
           "$baseCrudPath/${Uri.encodeComponent(id)}",
           query: enrichedQuery,
           headers: headers,
+          cancelToken: cancelToken,
+          requestKey: requestKey,
         )
         .then(itemFactoryFunc);
   }
@@ -131,6 +144,8 @@ abstract class BaseCrudService<M extends Jsonable> extends BaseService {
     String? fields,
     Map<String, dynamic> query = const {},
     Map<String, String> headers = const {},
+    CancelToken? cancelToken,
+    Object? requestKey = const Object(),
   }) {
     return getList(
       perPage: 1,
@@ -140,6 +155,8 @@ abstract class BaseCrudService<M extends Jsonable> extends BaseService {
       fields: fields,
       query: query,
       headers: headers,
+      cancelToken: cancelToken,
+      requestKey: requestKey,
     ).then((result) {
       if (result.items.isEmpty) {
         throw ClientException(
@@ -164,6 +181,8 @@ abstract class BaseCrudService<M extends Jsonable> extends BaseService {
     Map<String, String> headers = const {},
     String? expand,
     String? fields,
+    CancelToken? cancelToken,
+    Object? requestKey = const Object(),
   }) {
     final enrichedQuery = Map<String, dynamic>.of(query);
     enrichedQuery["expand"] ??= expand;
@@ -177,6 +196,8 @@ abstract class BaseCrudService<M extends Jsonable> extends BaseService {
           query: enrichedQuery,
           files: files,
           headers: headers,
+          cancelToken: cancelToken,
+          requestKey: requestKey,
         )
         .then(itemFactoryFunc);
   }
@@ -190,6 +211,8 @@ abstract class BaseCrudService<M extends Jsonable> extends BaseService {
     Map<String, String> headers = const {},
     String? expand,
     String? fields,
+    CancelToken? cancelToken,
+    Object? requestKey = const Object(),
   }) {
     final enrichedQuery = Map<String, dynamic>.of(query);
     enrichedQuery["expand"] ??= expand;
@@ -203,6 +226,8 @@ abstract class BaseCrudService<M extends Jsonable> extends BaseService {
           query: enrichedQuery,
           files: files,
           headers: headers,
+          cancelToken: cancelToken,
+          requestKey: requestKey,
         )
         .then(itemFactoryFunc);
   }
@@ -213,6 +238,8 @@ abstract class BaseCrudService<M extends Jsonable> extends BaseService {
     Map<String, dynamic> body = const {},
     Map<String, dynamic> query = const {},
     Map<String, String> headers = const {},
+    CancelToken? cancelToken,
+    Object? requestKey = const Object(),
   }) {
     return client.send(
       "$baseCrudPath/${Uri.encodeComponent(id)}",
@@ -220,6 +247,8 @@ abstract class BaseCrudService<M extends Jsonable> extends BaseService {
       body: body,
       query: query,
       headers: headers,
+      cancelToken: cancelToken,
+      requestKey: requestKey,
     );
   }
 }

--- a/lib/src/services/realtime_service.dart
+++ b/lib/src/services/realtime_service.dart
@@ -329,6 +329,7 @@ class RealtimeService extends BaseService {
         "clientId": _clientId,
         "subscriptions": _subscriptions.keys.toList(),
       },
+      requestKey: "realtime_$_clientId",
     );
   }
 }

--- a/lib/src/services/record_service.dart
+++ b/lib/src/services/record_service.dart
@@ -3,6 +3,7 @@ import "dart:convert";
 
 import "package:http/http.dart" as http;
 
+import "../cancel_token.dart";
 import "../client.dart";
 import "../client_exception.dart";
 import "../dtos/auth_method_provider.dart";
@@ -108,6 +109,8 @@ class RecordService extends BaseCrudService<RecordModel> {
     Map<String, String> headers = const {},
     String? expand,
     String? fields,
+    CancelToken? cancelToken,
+    Object? requestKey = const Object(),
   }) {
     return super
         .update(
@@ -118,6 +121,8 @@ class RecordService extends BaseCrudService<RecordModel> {
       headers: headers,
       expand: expand,
       fields: fields,
+      cancelToken: cancelToken,
+      requestKey: requestKey,
     )
         .then((item) {
       if (client.authStore.record != null &&
@@ -164,6 +169,8 @@ class RecordService extends BaseCrudService<RecordModel> {
     Map<String, dynamic> body = const {},
     Map<String, dynamic> query = const {},
     Map<String, String> headers = const {},
+    CancelToken? cancelToken,
+    Object? requestKey = const Object(),
   }) {
     return super
         .delete(
@@ -171,6 +178,8 @@ class RecordService extends BaseCrudService<RecordModel> {
       body: body,
       query: query,
       headers: headers,
+      cancelToken: cancelToken,
+      requestKey: requestKey,
     )
         .then((_) {
       if (client.authStore.record != null &&

--- a/test/cancel_token_test.dart
+++ b/test/cancel_token_test.dart
@@ -1,0 +1,125 @@
+// ignore_for_file: lines_longer_than_80_chars
+
+import "dart:async";
+
+import "package:pocketbase/pocketbase.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("CancelToken", () {
+    test("should be initially not cancelled", () {
+      final token = CancelToken();
+      expect(token.isCancelled, isFalse);
+      expect(token.reason, isNull);
+    });
+
+    test("should be cancelled when cancel() is called", () {
+      final token = CancelToken()..cancel("Test reason");
+      
+      expect(token.isCancelled, isTrue);
+      expect(token.reason, "Test reason");
+    });
+
+    test("should complete whenCancelled future when cancelled", () async {
+      final token = CancelToken();
+      var completed = false;
+
+      token.whenCancelled.then((_) => completed = true).ignore();
+      
+      // Should not be completed yet
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(completed, isFalse);
+      
+      // Cancel and check completion
+      token.cancel();
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(completed, isTrue);
+    });
+
+    test("should not cancel multiple times", () {
+      final token = CancelToken()
+        ..cancel("First reason")
+        ..cancel("Second reason");
+      
+      expect(token.isCancelled, isTrue);
+      expect(token.reason, "First reason");
+    });
+
+    test("should use default reason when none provided", () {
+      final token = CancelToken()..cancel();
+      
+      expect(token.reason, "Request was cancelled");
+    });
+
+    test("throwIfCancelled should throw when cancelled", () {
+      final token = CancelToken()..cancel("Test cancellation");
+      
+      expect(
+        token.throwIfCancelled,
+        throwsA(isA<CancellationException>()),
+      );
+    });
+
+    test("throwIfCancelled should not throw when not cancelled", () {
+      final token = CancelToken();
+      
+      expect(token.throwIfCancelled, returnsNormally);
+    });
+
+    test("combine should return cancelled token if first is cancelled", () {
+      final token1 = CancelToken()..cancel("Token 1 cancelled");
+      final token2 = CancelToken();
+      
+      final combined = token1.combine(token2);
+      
+      expect(combined.isCancelled, isTrue);
+      expect(combined.reason, "Token 1 cancelled");
+    });
+
+    test("combine should return cancelled token if second is cancelled", () {
+      final token1 = CancelToken();
+      final token2 = CancelToken()..cancel("Token 2 cancelled");
+      
+      final combined = token1.combine(token2);
+      
+      expect(combined.isCancelled, isTrue);
+      expect(combined.reason, "Token 2 cancelled");
+    });
+
+    test("combine should cancel when first token is cancelled later", () async {
+      final token1 = CancelToken();
+      final token2 = CancelToken();
+      final combined = token1.combine(token2);
+      
+      expect(combined.isCancelled, isFalse);
+      
+      token1.cancel("Token 1 cancelled later");
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      
+      expect(combined.isCancelled, isTrue);
+      expect(combined.reason, "Token 1 cancelled later");
+    });
+
+    test("combine should cancel when second token is cancelled later", () async {
+      final token1 = CancelToken();
+      final token2 = CancelToken();
+      final combined = token1.combine(token2);
+      
+      expect(combined.isCancelled, isFalse);
+      
+      token2.cancel("Token 2 cancelled later");
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      
+      expect(combined.isCancelled, isTrue);
+      expect(combined.reason, "Token 2 cancelled later");
+    });
+  });
+
+  group("CancellationException", () {
+    test("should have correct message", () {
+      const exception = CancellationException("Test message");
+      expect(exception.message, "Test message");
+      expect(exception.toString(), "CancellationException: Test message");
+    });
+  });
+}

--- a/test/client_cancellation_test.dart
+++ b/test/client_cancellation_test.dart
@@ -1,0 +1,345 @@
+// ignore_for_file: lines_longer_than_80_chars
+
+import "dart:async";
+
+import "package:http/http.dart" as http;
+import "package:http/testing.dart";
+import "package:pocketbase/pocketbase.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("PocketBase request cancellation", () {
+    test("should support manual cancellation with CancelToken", () async {
+      final client = PocketBase("https://example.com");
+      final cancelToken = CancelToken();
+      
+      client.httpClientFactory = () => MockClient((request) async {
+        // Simulate a slow request
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        return http.Response('{"test": "data"}', 200);
+      });
+
+      // Start request and cancel it immediately
+      final future = client.send(
+        "/api/test",
+        cancelToken: cancelToken,
+      );
+      
+      cancelToken.cancel("Manual cancellation");
+
+      expect(
+        () async => await future,
+        throwsA(
+          predicate((e) => 
+            e is ClientException && 
+            e.isAbort == true &&
+            e.originalError is CancellationException
+          ),
+        ),
+      );
+    });
+
+    test("should auto-cancel duplicate requests by default", () async {
+      final client = PocketBase("https://example.com")
+        ..httpClientFactory = () => MockClient((request) async {
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          return http.Response('{"test": "data"}', 200);
+        });
+
+      // Send multiple requests to the same endpoint
+      final future1 = client.send("/api/test");
+      final future2 = client.send("/api/test");
+      final future3 = client.send("/api/test");
+
+      // First two should be cancelled, last one should succeed
+      expect(
+        () async => await future1,
+        throwsA(predicate((e) => e is ClientException && e.isAbort == true)),
+      );
+      
+      expect(
+        () async => await future2,
+        throwsA(predicate((e) => e is ClientException && e.isAbort == true)),
+      );
+
+      final result = await future3;
+      expect(result, isNotNull);
+    });
+
+    test("should not auto-cancel when autoCancellation is disabled", () async {
+      final client = PocketBase("https://example.com")
+        ..autoCancellation(false);
+      var requestCount = 0;
+      
+      client.httpClientFactory = () => MockClient((request) async {
+        requestCount++;
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        return http.Response('{"test": "data"}', 200);
+      });
+
+      // Send multiple requests to the same endpoint
+      final future1 = client.send("/api/test");
+      final future2 = client.send("/api/test");
+      final future3 = client.send("/api/test");
+
+      // All should succeed
+      final results = await Future.wait([future1, future2, future3]);
+      expect(results.length, 3);
+      expect(requestCount, 3);
+    });
+
+    test("should use custom requestKey for cancellation", () async {
+      final client = PocketBase("https://example.com")
+        ..httpClientFactory = () => MockClient((request) async {
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          return http.Response('{"test": "data"}', 200);
+        });
+
+      // Send requests with same custom key
+      final future1 = client.send("/api/test1", requestKey: "customKey");
+      final future2 = client.send("/api/test2", requestKey: "customKey");
+      final future3 = client.send("/api/test3"); // Different endpoint, no custom key
+
+      // First should be cancelled by second
+      expect(
+        () async => await future1,
+        throwsA(predicate((e) => e is ClientException && e.isAbort == true)),
+      );
+
+      // Second and third should succeed
+      final results = await Future.wait([future2, future3]);
+      expect(results.length, 2);
+    });
+
+    test("should disable auto-cancellation with null requestKey", () async {
+      final client = PocketBase("https://example.com");
+      var requestCount = 0;
+      
+      client.httpClientFactory = () => MockClient((request) async {
+        requestCount++;
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        return http.Response('{"test": "data"}', 200);
+      });
+
+      // Send multiple requests with null requestKey
+      final future1 = client.send("/api/test", requestKey: null);
+      final future2 = client.send("/api/test", requestKey: null);
+
+      // Both should succeed
+      final results = await Future.wait([future1, future2]);
+      expect(results.length, 2);
+      expect(requestCount, 2);
+    });
+
+    test("cancelRequest should cancel specific request", () async {
+      final client = PocketBase("https://example.com")
+        ..httpClientFactory = () => MockClient((request) async {
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          return http.Response('{"test": "data"}', 200);
+        });
+
+      // Start request with custom key
+      final future = client.send("/api/test", requestKey: "cancelMe");
+      
+      // Cancel it manually
+      client.cancelRequest("cancelMe");
+
+      expect(
+        () async => await future,
+        throwsA(predicate((e) => e is ClientException && e.isAbort == true)),
+      );
+    });
+
+    test("cancelAllRequests should cancel all pending requests", () async {
+      final client = PocketBase("https://example.com")
+        ..httpClientFactory = () => MockClient((request) async {
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          return http.Response('{"test": "data"}', 200);
+        });
+
+      // Start multiple requests
+      final future1 = client.send("/api/test1", requestKey: "key1");
+      final future2 = client.send("/api/test2", requestKey: "key2");
+      final future3 = client.send("/api/test3", requestKey: "key3");
+      
+      // Cancel all
+      client.cancelAllRequests();
+
+      // All should be cancelled
+      expect(
+        () async => await future1,
+        throwsA(predicate((e) => e is ClientException && e.isAbort == true)),
+      );
+      
+      expect(
+        () async => await future2,
+        throwsA(predicate((e) => e is ClientException && e.isAbort == true)),
+      );
+      
+      expect(
+        () async => await future3,
+        throwsA(predicate((e) => e is ClientException && e.isAbort == true)),
+      );
+    });
+
+    test("should set autoCancellation correctly", () {
+      PocketBase("https://example.com")
+        ..autoCancellation(false)
+        ..autoCancellation(true);
+      // If no exception thrown, test passes
+      expect(true, isTrue);
+    });
+
+    test("should call cancelRequest without errors", () {
+      PocketBase("https://example.com")
+        ..cancelRequest("key1")
+        ..cancelRequest("key2");
+      // If no exception thrown, test passes
+      expect(true, isTrue);
+    });
+
+    test("should call cancelAllRequests without errors", () {
+      PocketBase("https://example.com").cancelAllRequests();
+      // If no exception thrown, test passes
+      expect(true, isTrue);
+    });
+
+    test("should handle cancellation with combined tokens", () async {
+      final client = PocketBase("https://example.com");
+      final userToken = CancelToken();
+      final parentToken = CancelToken();
+      final combinedToken = userToken.combine(parentToken);
+      
+      client.httpClientFactory = () => MockClient((request) async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        return http.Response('{"test": "data"}', 200);
+      });
+
+      final future = client.send(
+        "/api/test",
+        cancelToken: combinedToken,
+      );
+      
+      // Cancel parent token
+      parentToken.cancel("Parent cancelled");
+
+      expect(
+        () async => await future,
+        throwsA(predicate((e) => 
+          e is ClientException && 
+          e.isAbort == true &&
+          e.originalError is CancellationException
+        )),
+      );
+    });
+  });
+
+  group("Service method cancellation", () {
+    test("getList should support cancellation", () async {
+      final client = PocketBase("https://example.com");
+      final cancelToken = CancelToken();
+      
+      client.httpClientFactory = () => MockClient((request) async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        return http.Response('{"items": [], "totalItems": 0, "totalPages": 0, "page": 1, "perPage": 30}', 200);
+      });
+
+      final service = client.collection("test");
+      final future = service.getList(cancelToken: cancelToken);
+      
+      cancelToken.cancel();
+
+      expect(
+        () async => await future,
+        throwsA(predicate((e) => e is ClientException && e.isAbort == true)),
+      );
+    });
+
+    test("getOne should support cancellation", () async {
+      final client = PocketBase("https://example.com");
+      final cancelToken = CancelToken();
+      
+      client.httpClientFactory = () => MockClient((request) async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        return http.Response('{"id": "test", "created": "2023-01-01T00:00:00Z", "updated": "2023-01-01T00:00:00Z"}', 200);
+      });
+
+      final service = client.collection("test");
+      final future = service.getOne("test", cancelToken: cancelToken);
+      
+      cancelToken.cancel();
+
+      expect(
+        () async => await future,
+        throwsA(predicate((e) => e is ClientException && e.isAbort == true)),
+      );
+    });
+
+    test("create should support cancellation", () async {
+      final client = PocketBase("https://example.com");
+      final cancelToken = CancelToken();
+      
+      client.httpClientFactory = () => MockClient((request) async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        return http.Response('{"id": "test", "created": "2023-01-01T00:00:00Z", "updated": "2023-01-01T00:00:00Z"}', 200);
+      });
+
+      final service = client.collection("test");
+      final future = service.create(
+        body: {"name": "test"},
+        cancelToken: cancelToken,
+      );
+      
+      cancelToken.cancel();
+
+      expect(
+        () async => await future,
+        throwsA(predicate((e) => e is ClientException && e.isAbort == true)),
+      );
+    });
+
+    test("update should support cancellation", () async {
+      final client = PocketBase("https://example.com");
+      final cancelToken = CancelToken();
+      
+      client.httpClientFactory = () => MockClient((request) async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        return http.Response('{"id": "test", "created": "2023-01-01T00:00:00Z", "updated": "2023-01-01T00:00:00Z"}', 200);
+      });
+
+      final service = client.collection("test");
+      final future = service.update(
+        "test",
+        body: {"name": "updated"},
+        cancelToken: cancelToken,
+      );
+      
+      cancelToken.cancel();
+
+      expect(
+        () async => await future,
+        throwsA(predicate((e) => e is ClientException && e.isAbort == true)),
+      );
+    });
+
+    test("delete should support cancellation", () async {
+      final client = PocketBase("https://example.com");
+      final cancelToken = CancelToken();
+      
+      client.httpClientFactory = () => MockClient((request) async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        return http.Response("", 204);
+      });
+
+      final service = client.collection("test");
+      final future = service.delete("test", cancelToken: cancelToken);
+      
+      cancelToken.cancel();
+
+      expect(
+        () async => await future,
+        throwsA(predicate((e) => e is ClientException && e.isAbort == true)),
+      );
+    });
+  });
+}

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -81,7 +81,7 @@ void main() {
         "test5": 123,
         "test6": -123.45,
         "test7": 123.45,
-        "test8": DateTime(2023, 10, 18, 10, 11, 12),
+        "test8": DateTime.utc(2023, 10, 18, 10, 11, 12),
         "test9": [1, 2, 3, "test'123"],
         "test10": {"a": "test'123"},
       };
@@ -97,7 +97,7 @@ void main() {
 
       expect(
         client.filter(expr, params),
-        "test1='a\\'b\\'c\\'' || test2=null || test3=true || test4=false || test5=123 || test6=-123.45 || test7=123.45 || test8='2023-10-18 07:11:12.000Z' || test9='[1,2,3,\"test\\'123\"]' || test10='{\"a\":\"test\\'123\"}'",
+        "test1='a\\'b\\'c\\'' || test2=null || test3=true || test4=false || test5=123 || test6=-123.45 || test7=123.45 || test8='2023-10-18 10:11:12.000Z' || test9='[1,2,3,\"test\\'123\"]' || test10='{\"a\":\"test\\'123\"}'",
       );
     });
   });


### PR DESCRIPTION
- Add CancelToken class for request cancellation
- Add CancellationException for cancellation errors
- Implement auto-cancellation for duplicate requests
- Add manual cancellation methods to PocketBase client
- Update all service methods to support cancellation
- Add comprehensive test suite for cancellation features
- Create example demonstrating cancellation usage

Resolves GitHub issue https://github.com/pocketbase/dart-sdk/issues/70 - Request cancellation/abort feature